### PR TITLE
bump version to 1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.1.0
+TAG = 1.1.1
 DOCKERORG = quay.io/integreatly
 BROKER_IMAGE_NAME = managed-service-broker
 


### PR DESCRIPTION
Bump version to 1.1.1. This image version includes the following changes:
- https://github.com/integr8ly/managed-service-broker/pull/6