### PR TITLE
Remove fuse image streams creation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 1.1.1
+TAG = 1.0.1
 DOCKERORG = quay.io/integreatly
 BROKER_IMAGE_NAME = managed-service-broker
 

--- a/pkg/clients/openshift/openshift.go
+++ b/pkg/clients/openshift/openshift.go
@@ -3,7 +3,6 @@ package openshift
 import (
 	appsv1 "github.com/openshift/client-go/apps/clientset/versioned/typed/apps/v1"
 	authv1 "github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1"
-	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	routev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"k8s.io/client-go/rest"
 )
@@ -18,10 +17,6 @@ type ClientFactory struct {
 
 func (c *ClientFactory) AuthClient() (*authv1.AuthorizationV1Client, error) {
 	return authv1.NewForConfig(c.cfg)
-}
-
-func (c *ClientFactory) ImageStreamClient() (*imagev1.ImageV1Client, error) {
-	return imagev1.NewForConfig(c.cfg)
 }
 
 func (c *ClientFactory) AppsClient() (*appsv1.AppsV1Client, error) {

--- a/pkg/deploys/fuse/deployer.go
+++ b/pkg/deploys/fuse/deployer.go
@@ -81,15 +81,6 @@ func (fd *FuseDeployer) Deploy(instanceID, brokerNamespace string, contextProfil
 		}, err
 	}
 
-	// ImageStream
-	err = fd.createImageStream(namespace, osClientFactory)
-	if err != nil {
-		glog.Errorf("failed to create fuse image stream: %+v", err)
-		return &brokerapi.CreateServiceInstanceResponse{
-			Code: http.StatusInternalServerError,
-		}, err
-	}
-
 	// DeploymentConfig
 	err = fd.createFuseOperator(namespace, osClientFactory)
 	if err != nil {
@@ -185,22 +176,6 @@ func (fd *FuseDeployer) createRoleBindings(namespace string, userInfo v1.UserInf
 	_, err = authClient.RoleBindings(namespace).Create(getUserViewRoleBindingObj(namespace, userInfo.Username))
 	if err != nil {
 		return errors.Wrap(err, "failed to create user view role binding for fuse service")
-	}
-
-	return nil
-}
-
-func (fd *FuseDeployer) createImageStream(namespace string, osClientFactory *openshift.ClientFactory) error {
-	imageClient, err := osClientFactory.ImageStreamClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to create an openshift image stream client")
-	}
-
-	for _, imgStream := range getFuseOnlineImageStreamsObj() {
-		_, err = imageClient.ImageStreams(namespace).Create(&imgStream)
-		if err != nil {
-			return errors.Wrap(err, "failed to create "+imgStream.ObjectMeta.Name+" image stream for fuse service")
-		}
 	}
 
 	return nil

--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -5,11 +5,12 @@ import (
 	"github.com/integr8ly/managed-service-broker/pkg/deploys/fuse/pkg/apis/syndesis/v1alpha1"
 	appsv1 "github.com/openshift/api/apps/v1"
 	authv1 "github.com/openshift/api/authorization/v1"
-	imagev1 "github.com/openshift/api/image/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const FUSE_IMAGE_STREAMS_NAMESPACE string = "openshift"
 
 // Fuse plan
 func getCatalogServicesObj() []*brokerapi.Service {
@@ -240,183 +241,6 @@ func getEditRoleBindingObj() *authv1.RoleBinding {
 	}
 }
 
-func getFuseOnlineImageStreamsObj() []imagev1.ImageStream {
-	return []imagev1.ImageStream{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse-ignite-server",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "syndesis-server",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/fuse7/fuse-ignite-server:1.1-13",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "1.4",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse-ignite-ui",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "syndesis-ui",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/fuse7/fuse-ignite-ui:1.1-8",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "1.4",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse-ignite-meta",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "syndesis-meta",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/fuse7/fuse-ignite-meta:1.1-12",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "1.4",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "oauth-proxy",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "syndesis-oauthproxy",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "docker.io/openshift/oauth-proxy:v1.1.0",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "v1.1.0",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "prometheus",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "syndesis-prometheus",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/openshift3/prometheus:v3.9.25",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "v2.1.0",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse-ignite-s2i",
-				Labels: map[string]string{
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "infrastructure",
-					"syndesis.io/component": "s2i-java",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/fuse7/fuse-ignite-s2i:1.1-13",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "1.4",
-					},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "fuse-online-operator",
-				Labels: map[string]string{
-					"app":                   "syndesis",
-					"syndesis.io/app":       "syndesis",
-					"syndesis.io/type":      "operator",
-					"syndesis.io/component": "syndesis-operator",
-				},
-			},
-			Spec: imagev1.ImageStreamSpec{
-				LookupPolicy: imagev1.ImageLookupPolicy{
-					Local: true,
-				},
-				Tags: []imagev1.TagReference{
-					{
-						From: &corev1.ObjectReference{
-							Kind: "DockerImage",
-							Name: "registry.access.redhat.com/fuse7/fuse-online-operator:1.1-6",
-						},
-						ImportPolicy: imagev1.TagImportPolicy{
-							Scheduled: true,
-						},
-						Name: "1.4",
-					},
-				},
-			},
-		},
-	}
-}
-
 // Fuse operator deployment config
 func getDeploymentConfigObj() *appsv1.DeploymentConfig {
 	return &appsv1.DeploymentConfig{
@@ -476,8 +300,9 @@ func getDeploymentConfigObj() *appsv1.DeploymentConfig {
 							"syndesis-operator",
 						},
 						From: corev1.ObjectReference{
-							Kind: "ImageStreamTag",
-							Name: "fuse-online-operator:1.4",
+							Kind:      "ImageStreamTag",
+							Name:      "fuse-online-operator:1.4",
+							Namespace: FUSE_IMAGE_STREAMS_NAMESPACE,
 						},
 					},
 					Type: "ImageChange",
@@ -559,7 +384,7 @@ func getFuseObj(namespace, userNamespace string, integrationsLimit int) *v1alpha
 			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.SyndesisSpec{
-			ImageStreamNamespace: namespace,
+			ImageStreamNamespace: FUSE_IMAGE_STREAMS_NAMESPACE,
 			Integration: v1alpha1.IntegrationSpec{
 				Limit: &integrationsLimit,
 			},


### PR DESCRIPTION
The following changes includes: 
- Removal of Fuse image streams creation from the Fuse deployer.
- Specify `openshift` as the namespace where the Fuse operator should look into to get image streams to deploy the operator and Fuse online applications.

The Fuse image streams are now created in the `openshift` namespace during installation.

**Related PR**: https://github.com/integr8ly/installation/pull/113