### PR TITLE
#15 add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2 
+jobs: 
+  build: 
+    docker: 
+      - image: circleci/golang:1.8 
+    working_directory: /go/src/github.com/integr8ly/managed-service-broker
+
+    steps:
+      - checkout 
+      - setup_remote_docker
+      - run: make build_binary
+      - run: ./scripts/docker_build_and_push.sh
+    

--- a/scripts/docker_build_and_push.sh
+++ b/scripts/docker_build_and_push.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+APP_NAME=managed-service-broker
+
+IMAGE_MASTER_TAG=quay.io/integreatly/$APP_NAME:latest
+
+docker login --username $REGISTRY_USERNAME --password $REGISTRY_PASSWORD $REGISTRY_HOST
+docker build -t $IMAGE_MASTER_TAG -f ./tmp/build/broker/Dockerfile .
+docker push $IMAGE_MASTER_TAG


### PR DESCRIPTION
Add circleci config.yaml so that it will push an actual image to the latest image tag on quay.io.

Please note that I think this is not complete. I think there should be some mechanism setting   REGISTRY_USERNAME and REGISTRY_PASSWORD variables similar to tutorial-web-app (still investigating this).