### PR TITLE
Optional service class

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -130,7 +130,7 @@ func cancelOnInterrupt(ctx context.Context, f context.CancelFunc) {
 func shouldRegisterService(serviceName string )bool{
 	switch serviceName {
 	case "fuse":
-		return os.Getenv("FUSE_ENABLED") == "true"
+		return os.Getenv("FUSE_ENABLED") != "false"
 	case "launcher":
 		return os.Getenv("LAUNCHER_DASHBOARD_URL") != ""
 	case "che":

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -124,7 +124,7 @@ func cancelOnInterrupt(ctx context.Context, f context.CancelFunc) {
 
 func shouldRegisterService(services []string, serviceName string )bool{
 	for _, s := range services{
-		if strings.ToLower(s) == strings.ToLower(serviceName){
+		if strings.TrimSpace(strings.ToLower(s)) == strings.ToLower(serviceName){
 			return true
 		}
 	}

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -129,13 +129,13 @@ func cancelOnInterrupt(ctx context.Context, f context.CancelFunc) {
 
 func shouldRegisterService(serviceName string )bool{
 	switch serviceName {
-	case "fuse":
+	case fuseOnlineServiceName:
 		return os.Getenv("FUSE_ENABLED") != "false"
-	case "launcher":
+	case launcherServiceName:
 		return os.Getenv("LAUNCHER_DASHBOARD_URL") != ""
-	case "che":
+	case cheServiceName:
 		return os.Getenv("CHE_DASHBOARD_URL") != ""
-	case "3scale":
+	case threeScaleServiceName:
 		return os.Getenv("THREESCALE_DASHBOARD_URL") != ""
 	}
 	return false

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -59,6 +59,8 @@ objects:
               value: ${CHE_DASHBOARD_URL}
             - name: THREESCALE_DASHBOARD_URL
               value: ${THREESCALE_DASHBOARD_URL}
+            - name: MSB_SERVICES
+              value: ${MSB_SERVICES}
             ports:
             - containerPort: 8080
             readinessProbe:
@@ -182,6 +184,11 @@ parameters:
   - name: NAMESPACE
     description: Namespace of the project that is being deployed to
     value: "managed-service-broker"
+    required: true
+
+  - name: MSB_SERVICES
+    description: services that the MSB will generate service classes for
+    value: "fuse,che,launcher,3scale"
     required: true
 
   - name: IMAGE_ORG

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -59,8 +59,8 @@ objects:
               value: ${CHE_DASHBOARD_URL}
             - name: THREESCALE_DASHBOARD_URL
               value: ${THREESCALE_DASHBOARD_URL}
-            - name: MSB_SERVICES
-              value: ${MSB_SERVICES}
+            - name: FUSE_ENABLED
+              value: ${FUSE_ENABLED}
             ports:
             - containerPort: 8080
             readinessProbe:
@@ -186,9 +186,9 @@ parameters:
     value: "managed-service-broker"
     required: true
 
-  - name: MSB_SERVICES
-    description: services that the MSB will generate service classes for
-    value: "fuse,che,launcher,3scale"
+  - name: FUSE_ENABLED
+    description: whether to show a service class for fuse online
+    value: "true"
     required: true
 
   - name: IMAGE_ORG


### PR DESCRIPTION
## Motivation
Allow a service class to be turned off if the service is not present in the cluster

## Verification

- deploy the quay.io/integreatly/managed-service-broker:dev tag
- Ensure you can see all services
- set the env var for for each dashboard url to empty
- add a FUSE_ENABLED env var and set to "false"
- recreate the service broker resource
- You should see none of the services
Valid services are fuse, launcher,3scale,che

- go through the services and set a dashboard url and reload the broker
- you should see the services classes present 