### PR TITLE
Update travis push stage to update a branch tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,9 @@ jobs:
         - make build_image TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
     - stage: push
       script:
+        - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+        - export TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
         - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
-        - make build_image push TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
+        - make build_image push TAG=$TAG
+        - docker tag quay.io/integreatly/$NAME:$TAG quay.io/integreatly/$NAME:$BRANCH
+        - docker push quay.io/integreatly/$NAME:$BRANCH


### PR DESCRIPTION
## Motivation
This change allows a tag with the same name as the current branch (e.g. master) to be be created/updated when a branch is updated.

Main reason for this is so we can have a "master" tag always kept up to date when a PR is merged back.

## Verification Steps
* Ensure a tag is created/updated for this branch in quay.io https://quay.io/repository/integreatly/managed-service-broker