### PR TITLE
update fuse version to 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash
 REG = quay.io
 ORG = integreatly
 IMAGE = managed-service-broker
-TAG = 1.0.4
+TAG = master
 PROJECT = managed-service-broker
 
 .PHONY: code/run

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ test/e2e:
 .PHONY: cluster/prepare
 cluster/prepare:
 	@oc new-project $(PROJECT)
-	@oc create -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.4.8/resources/fuse-online-image-streams.yml -n openshift
+	@oc create -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.5/resources/fuse-online-image-streams.yml -n openshift
 	@oc create -f https://raw.githubusercontent.com/integr8ly/managed-service-controller/managed-service-controller-v1.0.0/deploy/fuse-image-stream.yaml -n openshift
-	@oc create -f https://raw.githubusercontent.com/syndesisio/syndesis/master/install/operator/deploy/syndesis-crd.yml
+	@oc create -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.5/resources/syndesis-crd.yml
 
 .PHONY: cluster/deploy
 cluster/deploy:
@@ -71,7 +71,7 @@ cluster/remove/deploy:
 
 .PHONY: cluster/clean
 cluster/clean:
-	@oc delete -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.4.8/resources/fuse-online-image-streams.yml -n openshift
+	@oc delete -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.5/resources/fuse-online-image-streams.yml -n openshift
 	@oc delete -f https://raw.githubusercontent.com/integr8ly/managed-service-controller/managed-service-controller-v1.0.0/deploy/fuse-image-stream.yaml -n openshift
-	@oc delete -f https://raw.githubusercontent.com/syndesisio/syndesis/master/install/operator/deploy/syndesis-crd.yml
+	@oc delete -f https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.5/resources/syndesis-crd.yml
 	@oc delete namespace $(PROJECT)

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -203,7 +203,7 @@ parameters:
 
   - name: IMAGE_TAG
     description: Tag of the broker image
-    value: "1.0.4"
+    value: "master"
 
   - name: IMAGE_PULL_POLICY
     value: "Always"


### PR DESCRIPTION
## Motivation
Update Fuse version to 1.5

## What
- Update the links for the Fuse image stream and Syndesis CRD to use version 1.5.
- Update tag to use `master` as version `1.0.4` does not exist.

## Verification Steps

Run `make cluster/prepare`
Ensure that all resources are successfully created.
Run `make cluster/deploy`
Ensure that the managed service broker is deployed successfully
Run `make cluster/clean` 
Ensure that all resources created during cluster preparation is successfully removed.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member