### PR TITLE
Add monitoring label to fuse namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ cluster/deploy:
       -p LAUNCHER_DASHBOARD_URL=http://launcher \
       -p THREESCALE_DASHBOARD_URL=http://3scale \
       -p APICURIO_DASHBOARD_URL=http://apicurio \
+      -p MONITORING_KEY=middleware \
       | oc create -f -
 
 .PHONY: cluster/remove/deploy
@@ -67,6 +68,7 @@ cluster/remove/deploy:
       -p LAUNCHER_DASHBOARD_URL=http://launcher \
       -p THREESCALE_DASHBOARD_URL=http://3scale \
       -p APICURIO_DASHBOARD_URL=http://apicurio \
+      -p MONITORING_KEY=middleware \
       | oc delete -f -
 
 .PHONY: cluster/clean

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -88,7 +88,7 @@ func runWithContext(ctx context.Context) error {
 
 	deployers := []controller.Deployer{}
 	if shouldRegisterService(fuseOnlineServiceName) {
-		deployers = append(deployers, fuse.NewDeployer(k8sClient, osClient))
+		deployers = append(deployers, fuse.NewDeployer(k8sClient, osClient, os.Getenv("MONITORING_KEY")))
 	}
 	if shouldRegisterService(launcherServiceName) {
 		deployers = append(deployers, launcher.NewDeployer())

--- a/pkg/deploys/fuse/deployer.go
+++ b/pkg/deploys/fuse/deployer.go
@@ -20,14 +20,16 @@ import (
 )
 
 type FuseDeployer struct {
-	k8sClient kubernetes.Interface
-	osClient  *openshift.ClientFactory
+	k8sClient     kubernetes.Interface
+	osClient      *openshift.ClientFactory
+	monitoringKey string
 }
 
-func NewDeployer(k8sClient kubernetes.Interface, osClient *openshift.ClientFactory) *FuseDeployer {
+func NewDeployer(k8sClient kubernetes.Interface, osClient *openshift.ClientFactory, mk string) *FuseDeployer {
 	return &FuseDeployer{
-		k8sClient: k8sClient,
-		osClient:  osClient,
+		k8sClient:     k8sClient,
+		osClient:      osClient,
+		monitoringKey: mk,
 	}
 }
 
@@ -40,7 +42,7 @@ func (fd *FuseDeployer) Deploy(req *brokerapi.ProvisionRequest, async bool) (*br
 	glog.Infof("Deploying fuse from deployer, id: %s", req.InstanceId)
 
 	// Namespace
-	ns, err := fd.k8sClient.CoreV1().Namespaces().Create(getNamespaceObj("fuse-" + req.InstanceId))
+	ns, err := fd.k8sClient.CoreV1().Namespaces().Create(getNamespaceObj("fuse-"+req.InstanceId, fd.monitoringKey))
 	if err != nil {
 		glog.Errorf("failed to create fuse namespace: %+v", err)
 		return &brokerapi.ProvisionResponse{

--- a/pkg/deploys/fuse/objects.go
+++ b/pkg/deploys/fuse/objects.go
@@ -58,10 +58,13 @@ func getCatalogServicesObj() []*brokerapi.Service {
 	}
 }
 
-func getNamespaceObj(id string) *corev1.Namespace {
+func getNamespaceObj(id, mk string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: id,
+			Labels: map[string]string{
+				"monitoring-key": mk,
+			},
 		},
 	}
 }

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -63,6 +63,8 @@ objects:
               value: ${APICURIO_DASHBOARD_URL}
             - name: FUSE_ENABLED
               value: ${FUSE_ENABLED}
+            - name: MONITORING_KEY
+              value: ${MONITORING_KEY}
             ports:
             - containerPort: 8080
             readinessProbe:
@@ -226,6 +228,10 @@ parameters:
 
   - name: APICURIO_DASHBOARD_URL
     description: APICurio dasbhoard url
+    required: true
+
+  - name: MONITORING_KEY
+    description: This value is applied to fuse namespaces to allow monitoring
     required: true
 
   - name: CA_BUNDLE


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-798

Adding the required monitoring label (`"monitoring-key": "<MONITORING_KEY_PARAM>"`) to the fuse namespaces

## Verification Steps
- [Create a cluster](https://github.com/integr8ly/managed-service-broker#deploying-the-broker)
- [Deploy managed-service-broker](https://github.com/integr8ly/managed-service-broker#deploy-managed-service-broker)
- Update the managed-service-broker image to `sedroche/managed-service-broker:monitoring-label`
- Provision a fuse instance
- Check the namespace labeling.

```
[root@bastion evals]# oc describe namespace fuse-ecd6e1c4-261e-11e9-87e5-0a580a010007
Name:         fuse-ecd6e1c4-261e-11e9-87e5-0a580a010007
Labels:       monitoring-key=middleware
Annotations:  alm-manager=operator-lifecycle-manager.olm-operator
              openshift.io/sa.scc.mcs=s0:c11,c10
              openshift.io/sa.scc.supplemental-groups=1000130000/10000
              openshift.io/sa.scc.uid-range=1000130000/10000
Status:       Active
```
