### PR TITLE
INTLY-747 Use different monitoring label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ cluster/deploy:
       -p LAUNCHER_DASHBOARD_URL=http://launcher \
       -p THREESCALE_DASHBOARD_URL=http://3scale \
       -p APICURIO_DASHBOARD_URL=http://apicurio \
-      -p MONITORING_KEY=middleware \
+      -p MONITORING_KEY=brokered-fuse-online \
       | oc create -f -
 
 .PHONY: cluster/remove/deploy
@@ -68,7 +68,7 @@ cluster/remove/deploy:
       -p LAUNCHER_DASHBOARD_URL=http://launcher \
       -p THREESCALE_DASHBOARD_URL=http://3scale \
       -p APICURIO_DASHBOARD_URL=http://apicurio \
-      -p MONITORING_KEY=middleware \
+      -p MONITORING_KEY=brokered-fuse-online \
       | oc delete -f -
 
 .PHONY: cluster/clean


### PR DESCRIPTION
We no longer want to monitor these, instead we will monitor the
one managed fuse installed by the Integreatly installer.

Verificiation:
- Run this against a cluster
- Login to the webapp
- Check the fuse namespace that's provisioned
- Ensure there is no middleware-monitoring label

