### PR TITLE
Intly 1243

### DIFF
--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/integr8ly/managed-service-broker/pkg/deploys/apicurio"
 	"github.com/integr8ly/managed-service-broker/pkg/deploys/che"
 	"github.com/integr8ly/managed-service-broker/pkg/deploys/fuse"
+	"github.com/integr8ly/managed-service-broker/pkg/deploys/fuse_managed"
 	"github.com/integr8ly/managed-service-broker/pkg/deploys/launcher"
 	"os"
 	"os/signal"
@@ -54,11 +55,12 @@ func run() error {
 }
 
 const (
-	threeScaleServiceName = "3scale"
-	fuseOnlineServiceName = "fuse"
-	cheServiceName        = "che"
-	launcherServiceName   = "launcher"
-	apicurioServiceName   = "apicurio"
+	threeScaleServiceName  = "3scale"
+	fuseOnlineServiceName  = "fuse"
+	cheServiceName         = "che"
+	launcherServiceName    = "launcher"
+	apicurioServiceName    = "apicurio"
+	fuseManagedServiceName = "fuse-managed"
 )
 
 func runWithContext(ctx context.Context) error {
@@ -112,6 +114,9 @@ func runWithContext(ctx context.Context) error {
 	if shouldRegisterService(apicurioServiceName) {
 		deployers = append(deployers, apicurio.NewDeployer())
 	}
+	if shouldRegisterService(fuseManagedServiceName) {
+		deployers = append(deployers, fuse_managed.NewDeployer())
+	}
 	ctrlr := controller.CreateController(deployers)
 
 	ctrlr.Catalog()
@@ -150,6 +155,8 @@ func shouldRegisterService(serviceName string) bool {
 		return os.Getenv("THREESCALE_DASHBOARD_URL") != ""
 	case apicurioServiceName:
 		return os.Getenv("APICURIO_DASHBOARD_URL") != ""
+	case fuseManagedServiceName:
+		return os.Getenv("SHARED_FUSE_DASHBOARD_URL") != ""
 	}
 	return false
 }

--- a/pkg/deploys/fuse_managed/deployer.go
+++ b/pkg/deploys/fuse_managed/deployer.go
@@ -1,0 +1,45 @@
+package fuse_managed
+
+import (
+	"net/http"
+	"os"
+
+	brokerapi "github.com/integr8ly/managed-service-broker/pkg/broker"
+	glog "github.com/sirupsen/logrus"
+)
+
+type FuseManagedDeployer struct{}
+
+func NewDeployer() *FuseManagedDeployer {
+	return &FuseManagedDeployer{}
+}
+
+func (fd *FuseManagedDeployer) GetCatalogEntries() []*brokerapi.Service {
+	glog.Infof("Getting fuse managed catalog entries")
+	return getCatalogServicesObj()
+}
+
+func (fd *FuseManagedDeployer) Deploy(req *brokerapi.ProvisionRequest, async bool) (*brokerapi.ProvisionResponse, error) {
+	glog.Infof("Deploying fuse managed from deployer, id: %s", req.InstanceId)
+
+	dashboardUrl := os.Getenv("SHARED_FUSE_DASHBOARD_URL")
+
+	return &brokerapi.ProvisionResponse{
+		Code:         http.StatusAccepted,
+		DashboardURL: dashboardUrl,
+		Operation:    "deploy",
+	}, nil
+}
+
+func (fd *FuseManagedDeployer) RemoveDeploy(req *brokerapi.DeprovisionRequest, async bool) (*brokerapi.DeprovisionResponse, error) {
+	return &brokerapi.DeprovisionResponse{Operation: "remove"}, nil
+}
+
+func (fd *FuseManagedDeployer) ServiceInstanceLastOperation(req *brokerapi.LastOperationRequest) (*brokerapi.LastOperationResponse, error) {
+	glog.Infof("Getting last operation for %s", req.InstanceId)
+
+	return &brokerapi.LastOperationResponse{
+		State:       brokerapi.StateSucceeded,
+		Description: "Managed Fuse deployed successfully",
+	}, nil
+}

--- a/pkg/deploys/fuse_managed/objects.go
+++ b/pkg/deploys/fuse_managed/objects.go
@@ -1,0 +1,33 @@
+package fuse_managed
+
+import (
+	brokerapi "github.com/integr8ly/managed-service-broker/pkg/broker"
+)
+
+// fuse managed plan
+func getCatalogServicesObj() []*brokerapi.Service {
+	return []*brokerapi.Service{
+		{
+			Name:        "fuse-managed",
+			ID:          "fuse-managed-service-id",
+			Description: "fuse managed",
+			Metadata:    map[string]string{"serviceName": "fuse-managed", "serviceType": "fuse"},
+			Plans: []brokerapi.ServicePlan{
+				{
+					Name:        "default-fuse-managed",
+					ID:          "default-fuse-managed",
+					Description: "default fuse-managed plan",
+					Free:        true,
+					Schemas: &brokerapi.Schemas{
+						ServiceBinding: &brokerapi.ServiceBindingSchema{
+							Create: &brokerapi.RequestResponseSchema{},
+						},
+						ServiceInstance: &brokerapi.ServiceInstanceSchema{
+							Create: &brokerapi.InputParametersSchema{},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -67,6 +67,8 @@ objects:
               value: ${MONITORING_KEY}
             - name: FUSE_OPERATOR_RESOURCES_URL
               value: ${FUSE_OPERATOR_RESOURCES_URL}
+            - name: SHARED_FUSE_DASHBOARD_URL
+              value: ${SHARED_FUSE_DASHBOARD_URL}
             ports:
             - containerPort: 8080
             readinessProbe:
@@ -235,6 +237,10 @@ parameters:
 
   - name: APICURIO_DASHBOARD_URL
     description: APICurio dasbhoard url
+    required: true
+
+  - name: SHARED_FUSE_DASHBOARD_URL
+    description: Shared fuse dasbhoard url
     required: true
 
   - name: MONITORING_KEY


### PR DESCRIPTION
Adds a new deployer for managed fuse. There are two fuse instances in an integreatly cluster: per-user and managed. We want to create a service instance for the managed one, so that the webapp can retrieve it's dashboard URL.