### PR TITLE
update cluster role to reflect new changes made in the fuse role

### DIFF
--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -114,15 +114,10 @@ objects:
       - clusterroles
       verbs: ["bind"]
     - apiGroups:
-      - rbac.authorization.k8s.io
-      resources:
-      - roles
-      verbs: ["create"]
-    - apiGroups:
       - syndesis.io
       resources:
-      - syndesises
-      - syndesises/finalizers
+      - "*"
+      - "*/finalizers"
       verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
     - apiGroups:
       - ""
@@ -143,6 +138,7 @@ objects:
     - apiGroups:
       - rbac.authorization.k8s.io
       resources:
+      - roles
       - rolebindings
       verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
     - apiGroups:
@@ -176,6 +172,24 @@ objects:
       - routes
       - routes/custom-host
       verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+    - apiGroups:
+      - camel.apache.org
+      resources:
+      - "*"
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
+    - apiGroups:
+      - monitoring.coreos.com
+      resources:
+      - alertmanagers
+      - prometheuses
+      - servicemonitors
+      - prometheusrules
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
+    - apiGroups:
+      - integreatly.org
+      resources:
+      - grafanadashboards
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
 
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding


### PR DESCRIPTION
## What
The `syndesis-operator` role has new permissions added for version 7.3 [1]. Update the managed-service cluster role to reflect these new changes made for the `syndesis-operator` role for Fuse Online.

This was also tested in the current master (fuse online v7.2)

[1] https://github.com/syndesisio/fuse-online-install/blob/1.6.13/templates/fuse-online-operator.yml#L12-L98

## Verification Steps
Test with both master and [fuse-online-rc](https://github.com/integr8ly/installation/tree/fuse-online-rc) branch.
1. Update the `msbroker_template` in the manifest file with:
   `https://raw.githubusercontent.com/JameelB/managed-service-broker/INTLY-1854/templates/broker.template.yaml`
2. Run the installer
    **NOTE**: Before running the installer for the `fuse-online-rc` branch, the job [openshift-cluster-brew-image-sync](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OpenShift/job/openshift-cluster-brew-image-sync/) must be ran first.
3. Go through `Walkthrough 1A`