### PR TITLE
Add cluster role with permissions needed to create roles for syndesis…

### DIFF
--- a/templates/broker.template.yaml
+++ b/templates/broker.template.yaml
@@ -204,6 +204,222 @@ objects:
       name: managed-service
       apiGroup: rbac.authorization.k8s.io
 
+  - kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: managed-service-role-for-syndesis-operator
+    rules:
+    - apiGroups:
+      - syndesis.io
+      resources:
+      - "*"
+      - "*/finalizers"
+      verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - configmaps
+      - secrets
+      - serviceaccounts
+      verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - apiGroups:
+      - ""
+      resources:
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - apps
+      resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - replicasets
+      - replicasets/scale
+      - statefulsets
+      - statefulsets/scale
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - extensions
+      resources:
+      - daemonsets
+      - deployments
+      - deployments/rollback
+      - deployments/scale
+      - ingresses
+      - networkpolicies
+      - replicasets
+      - replicasets/scale
+      - replicationcontrollers/scale
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - ""
+      resources:
+      - bindings
+      - events
+      - limitranges
+      - namespaces/status
+      - pods/log
+      - pods/status
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      verbs: [ get, list, watch ]
+    - apiGroups:
+      - ""
+      - build.openshift.io
+      resources:
+      - buildconfigs
+      - buildconfigs/webhooks
+      - builds
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - ""
+      - build.openshift.io
+      resources:
+      - buildconfigs/instantiate
+      - buildconfigs/instantiatebinary
+      - builds/clone
+      verbs: [ create ]
+    - apiGroups:
+      - ""
+      - build.openshift.io
+      resources:
+      - builds/details
+      verbs: [ update ]
+    - apiGroups:
+      - ""
+      - build.openshift.io
+      resources:
+      - builds/log
+      verbs: [ get, list, watch ]
+    - apiGroups:
+      - ""
+      - apps.openshift.io
+      resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - ""
+      - apps.openshift.io
+      resources:
+      - deploymentconfigrollbacks
+      - deploymentconfigs/instantiate
+      - deploymentconfigs/rollback
+      verbs: [ create ]
+    - apiGroups:
+      - ""
+      - apps.openshift.io
+      resources:
+      - deploymentconfigs/log
+      - deploymentconfigs/status
+      verbs: [ get, list, watch ]
+    - apiGroups:
+      - ""
+      - image.openshift.io
+      resources:
+      - imagestreams
+      - imagestreamimages
+      - imagestreammappings
+      - imagestreams/secrets
+      - imagestreamtags
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - ""
+      - image.openshift.io
+      resources:
+      - imagestreamimports
+      verbs: [ create ]
+    - apiGroups:
+      - ""
+      - image.openshift.io
+      resources:
+      - imagestreams/status
+      verbs: [ get, list, watch ]
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs: [ get, list ]
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - roles
+      - rolebindings
+      verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - apiGroups:
+      - ""
+      - template.openshift.io
+      resources:
+      - processedtemplates
+      - templateconfigs
+      - templateinstances
+      - templates
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - ""
+      - build.openshift.io
+      resources:
+      - buildlogs
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - authorization.openshift.io
+      resources:
+      - rolebindings
+      verbs: [ get, list, create, update, delete, deletecollection, watch ]
+    - apiGroups:
+      - route.openshift.io
+      resources:
+      - routes
+      - routes/custom-host
+      verbs: [ get, list, create, update, delete, deletecollection, watch, patch ]
+    - apiGroups:
+      - camel.apache.org
+      resources:
+      - "*"
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
+    - apiGroups:
+      - monitoring.coreos.com
+      resources:
+      - alertmanagers
+      - prometheuses
+      - servicemonitors
+      - prometheusrules
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
+    - apiGroups:
+      - integreatly.org
+      resources:
+      - grafanadashboards
+      verbs: [ get, list, create, update, delete, deletecollection, watch]
+    - apiGroups:
+      - serving.knative.dev
+      resources:
+      - services
+      verbs: [ get, list, watch]
+    - apiGroups:
+      - eventing.knative.dev
+      resources:
+      - channels
+      verbs: [ get, list, watch]
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: default-cluster-account-managed-service-for-syndesis-operator
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: ${NAMESPACE}
+    roleRef:
+      kind: ClusterRole
+      name: managed-service-role-for-syndesis-operator
+      apiGroup: rbac.authorization.k8s.io
+
 parameters:
   - name: NAMESPACE
     description: Namespace of the project that is being deployed to


### PR DESCRIPTION
…-operator

## Motivation
See https://issues.jboss.org/browse/INTLY-2752

## What

Take the Role from https://github.com/syndesisio/fuse-online-install/blob/master/resources/fuse-online-operator.yml#L12-L235 and add it here as a ClusterRole.
Also add a ClusterRoleBinding for the msb serviceaccount.

## Why
See https://issues.jboss.org/browse/INTLY-2752

## How
See PR

## Verification Steps

1. Use the fuse-online-rc branch of the integr8ly/installation repo
2. Install broker using the updated template.
3. Verify you can provision a fuse from the service catalog


## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member



## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
