### PR TITLE
Use correct name for pull secret

### DIFF
--- a/pkg/deploys/fuse/deployer.go
+++ b/pkg/deploys/fuse/deployer.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	fusePullSecretName = "syndesis-pull-secret"
+	fusePullSecretName = "imagestreamsecret"
 	fusePullSecretKey  = ".dockerconfigjson"
 )
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-2783

The pull secret name was changed during this installation change: 
https://github.com/integr8ly/installation/pull/753
https://github.com/integr8ly/installation/pull/753/files#diff-89e3f1efcec4d5d96033ca0d517e6424R5

This PR updates the secret name to match