### PR TITLE
Fix number of services in integration test again :)

### DIFF
--- a/tests/managedServicesBroker_test.go
+++ b/tests/managedServicesBroker_test.go
@@ -35,7 +35,7 @@ const (
 var (
 	envBrokerURL = os.Getenv(BROKER_URL)
 	envToken     = os.Getenv(KUBERNETES_API_TOKEN)
-	numServices  = 8
+	numServices  = 9
 )
 
 var (


### PR DESCRIPTION
Test is currently failing with ```--- FAIL: TestManagedBroker (0.58s)
05:13:11     managedServicesBroker_test.go:83: There should be 8 managed services, but there are 9 of them``` you can see https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/msb-integration-test/192/console
